### PR TITLE
Correct mistake in algorithm for `is_gaussian_prime`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,10 +188,9 @@ impl<T: PrimInt + Signed> GaussianInt<T> {
             (false, false) => {
                 let a = a.to_isize().unwrap();
                 let b = b.to_isize().unwrap();
-                let both_prime = is_prime(a) && is_prime(b);
                 let sum_of_squares = isize::pow(a, 2) + isize::pow(b, 2);
                 let sum_of_squares_is_4n_plus_3 = (sum_of_squares - 3) % 4 == 0;
-                both_prime && is_prime(sum_of_squares) && !sum_of_squares_is_4n_plus_3
+                is_prime(sum_of_squares) && !sum_of_squares_is_4n_plus_3
             }
             _ => false,
         };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -138,6 +138,12 @@ mod tests {
     }
 
     #[test]
+    fn is_gaussian_prime_2_plus_i() {
+        let c = gaussint!(2, 1);
+        assert_eq!(c.is_gaussian_prime(), true);
+    }
+
+    #[test]
     fn is_rational() {
         let c = gaussint!(7, 0);
         assert!(c.is_rational());


### PR DESCRIPTION
When a, b are both nonzero, a^2 + b^2 must be prime, but a and b need not be.