### PR TITLE
Require `num_integer::Integer` on integer types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ version = "0.5.1"
 dependencies = [
  "doc-comment",
  "num-complex",
+ "num-integer",
  "num-traits",
  "plotters",
  "primal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 doc-comment = "0.3.3"
 num-complex = "0.4.0"
+num-integer = "0.1.44"
 num-traits = "0.2"
 plotters = { version = "0.3.1", optional = true }
 primal = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ doctest!("../README.md", readme);
 use std::fmt;
 
 use num_complex::Complex;
+use num_integer::Integer;
 use num_traits::{PrimInt, Signed};
 
 mod ops;
@@ -25,7 +26,7 @@ mod ops;
 ///
 /// [Gaussian integer]: https://en.wikipedia.org/wiki/Gaussian_integer
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct GaussianInt<T: PrimInt>(pub Complex<T>);
+pub struct GaussianInt<T: PrimInt + Integer>(pub Complex<T>);
 
 /// Creates a new [`GaussianInt`].
 ///
@@ -49,7 +50,7 @@ macro_rules! gaussint {
     };
 }
 
-impl<T: PrimInt> GaussianInt<T> {
+impl<T: PrimInt + Integer> GaussianInt<T> {
     #[allow(missing_docs)]
     pub fn new(r: T, i: T) -> Self {
         Self(Complex::new(r, i))
@@ -81,7 +82,7 @@ impl<T: PrimInt> GaussianInt<T> {
     }
 }
 
-impl<T: PrimInt + Signed> GaussianInt<T> {
+impl<T: PrimInt + Integer + Signed> GaussianInt<T> {
     /// Returns the complex conjugate.
     ///
     /// # Example
@@ -279,7 +280,7 @@ impl GaussianInt<isize> {
     }
 }
 
-impl<T: PrimInt + Signed> GaussianInt<T>
+impl<T: PrimInt + Integer + Signed> GaussianInt<T>
 where
     f64: From<T>,
 {
@@ -333,19 +334,19 @@ pub fn get_g_ints(n: isize) -> impl Iterator<Item = GaussianInt<isize>> + 'stati
     primes.into_iter()
 }
 
-impl<T: PrimInt> From<Complex<T>> for GaussianInt<T> {
+impl<T: PrimInt + Integer> From<Complex<T>> for GaussianInt<T> {
     fn from(g: Complex<T>) -> Self {
         Self(g)
     }
 }
 
-impl<T: PrimInt> From<GaussianInt<T>> for isize {
+impl<T: PrimInt + Integer> From<GaussianInt<T>> for isize {
     fn from(g: GaussianInt<T>) -> Self {
         g.0.re.to_isize().unwrap()
     }
 }
 
-impl<T: PrimInt> fmt::Display for GaussianInt<T> {
+impl<T: PrimInt + Integer> fmt::Display for GaussianInt<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let zero = T::zero();
         if self.0.im < zero {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,42 +1,43 @@
 use crate::GaussianInt;
+use num_integer::Integer;
 use num_traits::{PrimInt, Signed};
 
-impl<T: PrimInt> std::ops::Add for GaussianInt<T> {
+impl<T: PrimInt + Integer> std::ops::Add for GaussianInt<T> {
     type Output = Self;
     fn add(self, other: Self) -> Self::Output {
         Self::new(self.0.re + other.0.re, self.0.im + other.0.im)
     }
 }
 
-impl<T: PrimInt> std::ops::Sub for GaussianInt<T> {
+impl<T: PrimInt + Integer> std::ops::Sub for GaussianInt<T> {
     type Output = Self;
     fn sub(self, other: Self) -> Self::Output {
         Self::new(self.0.re - other.0.re, self.0.im - other.0.im)
     }
 }
 
-impl<T: PrimInt> std::ops::Mul for GaussianInt<T> {
+impl<T: PrimInt + Integer> std::ops::Mul for GaussianInt<T> {
     type Output = Self;
     fn mul(self, other: Self) -> Self::Output {
         Self::from(self.0 * other.0)
     }
 }
 
-impl<T: PrimInt> std::ops::Div for GaussianInt<T> {
+impl<T: PrimInt + Integer> std::ops::Div for GaussianInt<T> {
     type Output = Self;
     fn div(self, other: Self) -> Self::Output {
         Self::from(self.0 / other.0)
     }
 }
 
-impl<T: PrimInt> std::ops::Rem for GaussianInt<T> {
+impl<T: PrimInt + Integer> std::ops::Rem for GaussianInt<T> {
     type Output = Self;
     fn rem(self, other: Self) -> Self::Output {
         Self::from(self.0 % other.0)
     }
 }
 
-impl<T: PrimInt + Signed> std::ops::Neg for GaussianInt<T> {
+impl<T: PrimInt + Integer + Signed> std::ops::Neg for GaussianInt<T> {
     type Output = Self;
     fn neg(self) -> Self::Output {
         Self::from(-self.0)


### PR DESCRIPTION
`GaussianInt<T>` already requires that `T` be [`num_traits::PrimInt`](https://docs.rs/num-traits/latest/num_traits/int/trait.PrimInt.html). This PR also requires that `T` implement [`num_integer::Integer`](https://docs.rs/num-integer/latest/num_integer/trait.Integer.html). This gives access to several useful methods for number-theoretic computation, especially [`is_multiple_of`](https://docs.rs/num-integer/0.1.44/num_integer/trait.Integer.html#tymethod.is_multiple_of), [`lcm`](https://docs.rs/num-integer/0.1.44/num_integer/trait.Integer.html#tymethod.lcm), [`gdc`](https://docs.rs/num-integer/0.1.44/num_integer/trait.Integer.html#tymethod.gcd).