### PR TITLE
Implement assignment operators in `num_traits::NumAssignOps`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,8 +2,10 @@
 
 - Implement `num_traits::One` and `num_traits::Zero` for `GaussianInt`.
 - Require integer types of `Gaussiant<T>` to implement [`num_integer::Integer`].
+- Implement assignment operators in [`num_traits::NumAssignOps`]
 
 [`num_integer::Integer`]: https://docs.rs/num-integer/latest/num_integer/trait.Integer.html
+[`num_traits::NumAssignOps`]: https://docs.rs/num-traits/latest/num_traits/trait.NumAssignOps.html
 
 ## v0.5.1 (2022-01-30)
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -44,14 +44,34 @@ impl<T: PrimInt + Integer + Signed> std::ops::Neg for GaussianInt<T> {
     }
 }
 
+// assignment ops
+
 impl<T: PrimInt + Integer> std::ops::AddAssign for GaussianInt<T> {
     fn add_assign(&mut self, other: Self) {
         *self = Self::from(self.0 + other.0)
     }
 }
 
-// impl<T: PrimInt + Integer> std::ops::SubAssign for GaussianInt<T> {}
-// impl<T: PrimInt + Integer> std::ops::MulAssign for GaussianInt<T> {}
+impl<T: PrimInt + Integer> std::ops::SubAssign for GaussianInt<T> {
+    fn sub_assign(&mut self, other: Self) {
+        *self = Self::from(self.0 - other.0)
+    }
+}
 
-// impl<T: PrimInt + Integer> std::ops::DivAssign for GaussianInt<T> {}
-// impl<T: PrimInt + Integer> std::ops::RemAssign for GaussianInt<T> {}
+impl<T: PrimInt + Integer> std::ops::MulAssign for GaussianInt<T> {
+    fn mul_assign(&mut self, other: Self) {
+        *self = Self::from(self.0 * other.0)
+    }
+}
+
+impl<T: PrimInt + Integer> std::ops::DivAssign for GaussianInt<T> {
+    fn div_assign(&mut self, other: Self) {
+        *self = Self::from(self.0 / other.0)
+    }
+}
+
+impl<T: PrimInt + Integer> std::ops::RemAssign for GaussianInt<T> {
+    fn rem_assign(&mut self, other: Self) {
+        *self = Self::from(self.0 % other.0)
+    }
+}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -44,8 +44,14 @@ impl<T: PrimInt + Integer + Signed> std::ops::Neg for GaussianInt<T> {
     }
 }
 
-// impl<T: PrimInt + Integer> std::ops::AddAssign for GaussianInt<T> {}
+impl<T: PrimInt + Integer> std::ops::AddAssign for GaussianInt<T> {
+    fn add_assign(&mut self, other: Self) {
+        *self = Self::from(self.0 + other.0)
+    }
+}
+
 // impl<T: PrimInt + Integer> std::ops::SubAssign for GaussianInt<T> {}
 // impl<T: PrimInt + Integer> std::ops::MulAssign for GaussianInt<T> {}
+
 // impl<T: PrimInt + Integer> std::ops::DivAssign for GaussianInt<T> {}
 // impl<T: PrimInt + Integer> std::ops::RemAssign for GaussianInt<T> {}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -43,3 +43,9 @@ impl<T: PrimInt + Integer + Signed> std::ops::Neg for GaussianInt<T> {
         Self::from(-self.0)
     }
 }
+
+// impl<T: PrimInt + Integer> std::ops::AddAssign for GaussianInt<T> {}
+// impl<T: PrimInt + Integer> std::ops::SubAssign for GaussianInt<T> {}
+// impl<T: PrimInt + Integer> std::ops::MulAssign for GaussianInt<T> {}
+// impl<T: PrimInt + Integer> std::ops::DivAssign for GaussianInt<T> {}
+// impl<T: PrimInt + Integer> std::ops::RemAssign for GaussianInt<T> {}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -40,6 +40,14 @@ mod tests {
     }
 
     #[test]
+    fn add_assign() {
+        let mut c1 = gaussint!(1, 1);
+        let c2 = gaussint!(2, 3);
+        c1 += c2;
+        assert_eq!(c1, gaussint!(3, 4));
+    }
+
+    #[test]
     fn subtraction() {
         let c1 = gaussint!(1, 1);
         let c2 = gaussint!(1, 1);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -59,6 +59,14 @@ mod tests {
     }
 
     #[test]
+    fn sub_assign() {
+        let mut c1 = gaussint!(1, 1);
+        let c2 = gaussint!(1, 1);
+        c1 -= c2;
+        assert_eq!(c1, gaussint!(0, 0));
+    }
+
+    #[test]
     fn norm() {
         let c = gaussint!(1, 1);
         assert_eq!(c.norm(), gaussint!(2, 0));
@@ -83,11 +91,28 @@ mod tests {
     }
 
     #[test]
+    fn mul_assign() {
+        let mut c1 = gaussint!(1, 1);
+        let c2 = gaussint!(1, -1);
+        c1 *= c2;
+        assert_eq!(c1, gaussint!(2, 0));
+    }
+
+    #[test]
     fn division() {
         // See https://projecteuler.net/problem=153
         let c1 = gaussint!(5, 0);
         let c2 = gaussint!(1, 2);
         assert_eq!(c1 / c2, gaussint!(1, -2));
+    }
+
+    #[test]
+    fn div_assign() {
+        // See https://projecteuler.net/problem=153
+        let mut c1 = gaussint!(5, 0);
+        let c2 = gaussint!(1, 2);
+        c1 /= c2;
+        assert_eq!(c1, gaussint!(1, -2));
     }
 
     #[test]
@@ -99,6 +124,15 @@ mod tests {
         let c1 = gaussint!(1, 2);
         let c2 = gaussint!(3, 4);
         assert!(c1 % c2 != GaussianInt::zero());
+    }
+
+    #[test]
+    fn rem_assign() {
+        // imaginary 🍪s
+        let mut jar = gaussint!(31);
+        let piles_of_cookies = gaussint!(4);
+        jar %= piles_of_cookies;
+        assert_eq!(jar, gaussint!(3));
     }
 
     #[test]


### PR DESCRIPTION
`GuassianInt` now implements `AddAssign`, `SubAssign`, `MulAssign`, `DivAssign`, and `RemAssign`.

Closes #18.